### PR TITLE
Added flex dependency so that you can use rosdep to install the prerequisites.

### DIFF
--- a/rosplan_knowledge_base/CMakeLists.txt
+++ b/rosplan_knowledge_base/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
+find_package(FLEX REQUIRED)
+
 find_package(Boost REQUIRED COMPONENTS
   filesystem
 )

--- a/rosplan_knowledge_base/package.xml
+++ b/rosplan_knowledge_base/package.xml
@@ -13,6 +13,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>flex</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
@@ -24,6 +25,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
+  <run_depend>flex</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>

--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -33,6 +33,8 @@ include_directories(
   include
 )
 
+find_package(FLEX REQUIRED)
+
 ## visualisation
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)

--- a/rosplan_planning_system/package.xml
+++ b/rosplan_planning_system/package.xml
@@ -14,6 +14,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>flex</build_depend>
   <build_depend>rosplan_dispatch_msgs</build_depend>
   <build_depend>rosplan_knowledge_msgs</build_depend>
 
@@ -22,6 +23,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
+  <run_depend>flex</run_depend>
   <run_depend>rosplan_dispatch_msgs</run_depend>
   <run_depend>rosplan_knowledge_msgs</run_depend>
 


### PR DESCRIPTION
By having flex as a dependency you can install all the prerequisites using rosdep:
```
cd ~/catkin_ws/src
rosdep update
rosdep install --from-paths . --ignore-src --rosdistro hydro -y
```
Tested only with ros-hydro.