### PR TITLE
Added GLUT dependency so that you can use rosdep to install it.

### DIFF
--- a/rosplan_planning_system/package.xml
+++ b/rosplan_planning_system/package.xml
@@ -15,6 +15,7 @@
   <build_depend>std_srvs</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>flex</build_depend>
+  <build_depend>glut</build_depend>
   <build_depend>rosplan_dispatch_msgs</build_depend>
   <build_depend>rosplan_knowledge_msgs</build_depend>
 
@@ -24,6 +25,7 @@
   <run_depend>std_srvs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>flex</run_depend>
+  <run_depend>glut</run_depend>
   <run_depend>rosplan_dispatch_msgs</run_depend>
   <run_depend>rosplan_knowledge_msgs</run_depend>
 


### PR DESCRIPTION
By having `glut` as a dependency you can install it using `rosdep`:
```
cd ~/catkin_ws/src
rosdep update
rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO -y
```
Tested with ros-hydro and ros-indigo.
