### PR TITLE
Fixing YAML so the last call doesn't cause an error

### DIFF
--- a/rosplan_demos/scripts/turtlebot_explore.bash
+++ b/rosplan_demos/scripts/turtlebot_explore.bash
@@ -31,12 +31,12 @@ knowledge:
 done;
 rosservice call /kcl_rosplan/update_knowledge_base "update_type: 0
 knowledge:
-knowledge_type: 1
-instance_type: ''
-instance_name: ''
-attribute_name: 'robot_at'
+  knowledge_type: 1
+  instance_type: ''
+  instance_name: ''
+  attribute_name: 'robot_at'
   values:
   - {key: 'v', value: 'kenny'}
   - {key: 'wp', value: 'wp0'}
-function_value: 0.0";
+  function_value: 0.0";
 rosservice call /kcl_rosplan/planning_server;

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
@@ -16,7 +16,8 @@ from rosplan_knowledge_msgs.msg import *
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt, QTimer, Signal, Slot
-from python_qt_binding.QtGui import QHeaderView, QIcon, QTreeWidgetItem, QListWidgetItem, QWidget
+from python_qt_binding.QtGui import QIcon
+from python_qt_binding.QtWidgets import QHeaderView, QTreeWidgetItem, QListWidgetItem, QWidget
 
 class PlanViewWidget(QWidget):
 
@@ -86,7 +87,7 @@ class PlanViewWidget(QWidget):
         self._plugin = plugin
         self.planView.sortByColumn(0, Qt.AscendingOrder)
         header = self.planView.header()
-        header.setResizeMode(QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(QHeaderView.ResizeToContents)
 
         # setup plan view columns
         self._column_index = {}


### PR DESCRIPTION
There seems to be an indentation problem in the turtle demo script.  This gets it working on Xenial/Kinetic. This was the error it fixed:
```
$ bash src/rosplan/rosplan_demos/scripts/turtlebot_explore.bash 
waypoints: ['wp0', 'wp1', 'wp2', 'wp3', 'wp4']
success: True
success: True
success: True
success: True
success: True
success: True
success: True
Traceback (most recent call last):
  File "/opt/ros/kinetic/bin/rosservice", line 35, in <module>
    rosservice.rosservicemain()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rosservice/__init__.py", line 746, in rosservicemain
    _rosservice_cmd_call(argv)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rosservice/__init__.py", line 607, in _rosservice_cmd_call
    service_args.append(yaml.load(arg))
  File "/usr/lib/python2.7/dist-packages/yaml/__init__.py", line 71, in load
    return loader.get_single_data()
  File "/usr/lib/python2.7/dist-packages/yaml/constructor.py", line 37, in get_single_data
    node = self.get_single_node()
  File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/usr/lib/python2.7/dist-packages/yaml/composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
  File "/usr/lib/python2.7/dist-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/usr/lib/python2.7/dist-packages/yaml/parser.py", line 439, in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block mapping
  in "<string>", line 1, column 1:
    update_type: 0
    ^
expected <block end>, but found '<block mapping start>'
  in "<string>", line 7, column 3:
      values:
      ^

```