### PR TITLE
Simple configurable constraints for parallel dispatch of actions

### DIFF
--- a/rosplan_planning_system/include/rosplan_planning_system/POPFEsterelPlanParser.h
+++ b/rosplan_planning_system/include/rosplan_planning_system/POPFEsterelPlanParser.h
@@ -33,6 +33,9 @@ namespace KCL_rosplan {
 		// Knowledge base
 		ros::ServiceClient update_knowledge_client;
 
+		// Configuration parameters
+		std::set<std::string> concurrency_constraining_types;
+
 		/* post process plan */
 		void toLowerCase(std::string &str);
 		void preparePDDLConditions(StrlNode &node, PlanningEnvironment &environment);

--- a/rosplan_planning_system/src/POPFEsterelPlanParser.cpp
+++ b/rosplan_planning_system/src/POPFEsterelPlanParser.cpp
@@ -376,7 +376,7 @@ namespace KCL_rosplan {
 			if((*nit)->input.size() > 0) {
 				dest << "  await ";
 				for(int j=0;j<(*nit)->input.size();j++) {
-					if(j>0) dest << " or ";
+					if(j>0) dest << " and ";
 					dest << (*nit)->input[j]->edge_name;
 				}
 				dest << ";" << std::endl;

--- a/rosplan_planning_system/src/POPFEsterelPlanParser.cpp
+++ b/rosplan_planning_system/src/POPFEsterelPlanParser.cpp
@@ -341,7 +341,7 @@ namespace KCL_rosplan {
 		// run everything
 		nit = plan_nodes.begin();
 		if(nit!=plan_nodes.end()) {
-			dest << "run action" << (*nit)->node_id << std::endl;
+			dest << "run action" << (*(nit++))->node_id << std::endl;
 			for(; nit!=plan_nodes.end(); nit++) {
 				dest << " || action" << (*nit)->node_id << std::endl;
 			}


### PR DESCRIPTION
Hi,

With guidance from the authors we used ROSplan to dispatch actions in parallel in a PhD student project.
We propose that until parallel execution is implemented in full, this new parameter can be used to configure the dispatcher for a specific domain and allowing parallel dispatch.

We also had to make some changes to the dispatch routine to make it wait for completion of all the connected previous actions. It may need further modifications to fully retain its previous properties, but we had no problem during our testing.

Best regards,
David Gillsjö
