### PR TITLE
Op and pred visitor need to be reset after visiting

### DIFF
--- a/rosplan_knowledge_base/include/rosplan_knowledge_base/KnowledgeBase.h
+++ b/rosplan_knowledge_base/include/rosplan_knowledge_base/KnowledgeBase.h
@@ -38,10 +38,6 @@ namespace KCL_rosplan {
 	{
 	private:
 
-		// visit controllers for ROS message packing
-		VALVisitorOperator op_visitor;
-		VALVisitorPredicate pred_visitor;
-
 		// adding and removing items to and from the knowledge base
 		void addKnowledge(rosplan_knowledge_msgs::KnowledgeItem &msg);
 		void addMissionGoal(rosplan_knowledge_msgs::KnowledgeItem &msg);

--- a/rosplan_knowledge_base/src/KnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/KnowledgeBase.cpp
@@ -409,7 +409,7 @@ namespace KCL_rosplan {
 
 	/* get domain operator details */
 	bool KnowledgeBase::getOperatorDetails(rosplan_knowledge_msgs::GetDomainOperatorDetailsService::Request  &req, rosplan_knowledge_msgs::GetDomainOperatorDetailsService::Response &res) {
-
+		VALVisitorOperator op_visitor;
 		VAL::operator_list* operators = domain_parser.domain->ops;
 		for (VAL::operator_list::const_iterator ci = operators->begin(); ci != operators->end(); ci++) {			
 			if((*ci)->name->symbol::getName() == req.name) {
@@ -423,7 +423,7 @@ namespace KCL_rosplan {
 
 	/* get domain predicate details */
 	bool KnowledgeBase::getPredicateDetails(rosplan_knowledge_msgs::GetDomainPredicateDetailsService::Request  &req, rosplan_knowledge_msgs::GetDomainPredicateDetailsService::Response &res) {
-
+		VALVisitorPredicate pred_visitor;
 		VAL::pred_decl_list* predicates = domain_parser.domain->predicates;
 		for (VAL::pred_decl_list::const_iterator ci = predicates->begin(); ci != predicates->end(); ci++) {			
 			if((*ci)->getPred()->symbol::getName() == req.name) {


### PR DESCRIPTION
With op_visitor as a class member (and not being reset), every time I called
`rosservice call /kcl_rosplan/get_domain_operator_details "name: 'goto_waypoint'"` the returned parameters would grow.  This caused RPActionInterface to bomb out when it wrongly inferred that incoming actions were missing parameters.

This pull puts the visitors into their respective functions, where they are created and destroyed with every call.