### PR TITLE
Fixing YAML indentation so the last call doesn't cause an error

### DIFF
--- a/rosplan_demos/scripts/turtlebot_explore.bash
+++ b/rosplan_demos/scripts/turtlebot_explore.bash
@@ -31,12 +31,12 @@ knowledge:
 done;
 rosservice call /kcl_rosplan/update_knowledge_base "update_type: 0
 knowledge:
-knowledge_type: 1
-instance_type: ''
-instance_name: ''
-attribute_name: 'robot_at'
+  knowledge_type: 1
+  instance_type: ''
+  instance_name: ''
+  attribute_name: 'robot_at'
   values:
   - {key: 'v', value: 'kenny'}
   - {key: 'wp', value: 'wp0'}
-function_value: 0.0";
+  function_value: 0.0";
 rosservice call /kcl_rosplan/planning_server;


### PR DESCRIPTION
This fixes the previous pull req which erroneously contained a fix for Qt5, which would not work on Indigo systems.  I'll put that fix as its own pull request that can be ignored.