### PR TITLE
Widgets moved out of QtGui in Qt5

### DIFF
--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
@@ -16,7 +16,8 @@ from rosplan_knowledge_msgs.msg import *
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Qt, QTimer, Signal, Slot
-from python_qt_binding.QtGui import QHeaderView, QIcon, QTreeWidgetItem, QListWidgetItem, QWidget
+from python_qt_binding.QtGui import QIcon
+from python_qt_binding.QtWidgets import QHeaderView, QTreeWidgetItem, QListWidgetItem, QWidget
 
 class PlanViewWidget(QWidget):
 
@@ -86,7 +87,7 @@ class PlanViewWidget(QWidget):
         self._plugin = plugin
         self.planView.sortByColumn(0, Qt.AscendingOrder)
         header = self.planView.header()
-        header.setResizeMode(QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(QHeaderView.ResizeToContents)
 
         # setup plan view columns
         self._column_index = {}


### PR DESCRIPTION
This fixes the rqt plugin for ROS Kinetic platforms that use Qt5.  I don't expect it to work on ROS Indigo platforms.