### PR TITLE
Qt5 support and some bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 #gedit
 *~
+
+# MongoDB database files
+/rosplan_knowledge_base/common/mongoDB

--- a/rosplan_knowledge_base/src/KnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/KnowledgeBase.cpp
@@ -240,15 +240,23 @@ namespace KCL_rosplan {
 			}
 
 		} else if(msg.knowledge_type == rosplan_knowledge_msgs::KnowledgeItem::FACT) {
-
 			// add domain attribute
+
+			std::string param_str;
+			for (size_t i = 0; i < msg.values.size(); ++i) {
+				param_str += " " + msg.values[i].key + "=" + msg.values[i].value;
+			}
+
 			std::vector<rosplan_knowledge_msgs::KnowledgeItem>::iterator pit;
 			for(pit=model_facts.begin(); pit!=model_facts.end(); pit++) {
 				if(KnowledgeComparitor::containsKnowledge(msg, *pit)) {
+          ROS_WARN("KCL: (KB) Domain attribute (%s%s) already exists",
+                   msg.attribute_name.c_str(), param_str.c_str());
 					return;
 				}
 			}
-			ROS_INFO("KCL: (KB) Adding domain attribute (%s)", msg.attribute_name.c_str());
+			ROS_INFO("KCL: (KB) Adding domain attribute (%s%s)",
+			         msg.attribute_name.c_str(), param_str.c_str());
 			model_facts.push_back(msg);
 			plan_filter.checkFilters(msg, true);
 
@@ -275,12 +283,22 @@ namespace KCL_rosplan {
 	 */
 	void KnowledgeBase::addMissionGoal(rosplan_knowledge_msgs::KnowledgeItem &msg) {
 
+		std::string param_str;
+		for (size_t i = 0; i < msg.values.size(); ++i) {
+			param_str += " " + msg.values[i].key + "=" + msg.values[i].value;
+		}
+
 		std::vector<rosplan_knowledge_msgs::KnowledgeItem>::iterator pit;
 		for(pit=model_goals.begin(); pit!=model_goals.end(); pit++) {
-			if(KnowledgeComparitor::containsKnowledge(msg, *pit))
+			if(KnowledgeComparitor::containsKnowledge(msg, *pit)) {
+				ROS_WARN("KCL: (KB) Goal (%s%s) already posted",
+				         msg.attribute_name.c_str(), param_str.c_str());
 				return;
+			}
 		}
-		ROS_INFO("KCL: (KB) Adding mission goal (%s)", msg.attribute_name.c_str());
+		
+		ROS_INFO("KCL: (KB) Adding mission goal (%s%s)",
+		         msg.attribute_name.c_str(), param_str.c_str());
 		model_goals.push_back(msg);
 	}
 

--- a/rosplan_knowledge_base/src/KnowledgeComparitor.cpp
+++ b/rosplan_knowledge_base/src/KnowledgeComparitor.cpp
@@ -1,5 +1,7 @@
 #include "rosplan_knowledge_base/KnowledgeComparitor.h"
 
+#include <boost/algorithm/string.hpp>
+
 /* implementation of KnowledgeComparitor.h */
 namespace KCL_rosplan {
 
@@ -14,24 +16,26 @@ namespace KCL_rosplan {
 			
 			// check instance knowledge
 			if(0!=a.instance_type.compare(b.instance_type)) return false;
-			if(a.instance_name!="" && 0!=a.instance_name.compare(b.instance_name)) return false;
+			if(a.instance_name!="" && ! boost::iequals(a.instance_name, b.instance_name)) return false;
 
 		} else {
 
 			// check fact or function
-			if(a.attribute_name!="" && 0!=a.attribute_name.compare(b.attribute_name)) return false;
+			if(a.attribute_name!="" && ! boost::iequals(a.attribute_name, b.attribute_name)) return false;
 			if(a.is_negative != b.is_negative) return false;
 			if(a.values.size() != b.values.size()) return false;
 
 			for(size_t i=0;i<a.values.size();i++) {
 
 				// don't care about this parameter
-				if(""==a.values[i].value) continue;
+				if("" == a.values[i].value) continue;
 
 				// find matching object in parameters of b
 				bool found = false;
 				for(size_t i=0;i<b.values.size();i++) {
-					 if(a.values[i].key == b.values[i].key && a.values[i].value == b.values[i].value) {
+					if(boost::iequals(a.values[i].key, b.values[i].key) &&
+					   boost::iequals(a.values[i].value, b.values[i].value))
+					{
 						found = true;
 						break;
 					}
@@ -52,7 +56,7 @@ namespace KCL_rosplan {
 			return true;
 
 		for(size_t i=0;i<a.values.size();i++) {
-			if(0==a.values[i].value.compare(name))
+			if(boost::iequals(a.values[i].value, name))
 				return true;
 		}
 

--- a/rosplan_knowledge_base/src/KnowledgeComparitor.cpp
+++ b/rosplan_knowledge_base/src/KnowledgeComparitor.cpp
@@ -31,16 +31,13 @@ namespace KCL_rosplan {
 				if("" == a.values[i].value) continue;
 
 				// find matching object in parameters of b
-				bool found = false;
 				for(size_t i=0;i<b.values.size();i++) {
-					if(boost::iequals(a.values[i].key, b.values[i].key) &&
-					   boost::iequals(a.values[i].value, b.values[i].value))
+					if(! boost::iequals(a.values[i].key, b.values[i].key) ||
+					   ! boost::iequals(a.values[i].value, b.values[i].value))
 					{
-						found = true;
-						break;
+						return false;
 					}
 				}
-				if(!found) return false;
 			}
 		}
 

--- a/rosplan_planning_system/src/PlanningSystem.cpp
+++ b/rosplan_planning_system/src/PlanningSystem.cpp
@@ -26,8 +26,8 @@ namespace KCL_rosplan {
 		// publishing "action_dispatch", "action_feedback", "plan"; listening "action_feedback"
 		plan_publisher = nh.advertise<rosplan_dispatch_msgs::CompletePlan>("/kcl_rosplan/plan", 5, true);
 		problem_publisher = nh.advertise<std_msgs::String>("/kcl_rosplan/problem", 5, true);
-		plan_dispatcher->action_publisher = nh.advertise<rosplan_dispatch_msgs::ActionDispatch>("/kcl_rosplan/action_dispatch", 1000, true);
-		plan_dispatcher->action_feedback_pub = nh.advertise<rosplan_dispatch_msgs::ActionFeedback>("/kcl_rosplan/action_feedback", 5, true);
+		plan_dispatcher->action_publisher = nh.advertise<rosplan_dispatch_msgs::ActionDispatch>("/kcl_rosplan/action_dispatch", 1000, /* latch */ false);
+		plan_dispatcher->action_feedback_pub = nh.advertise<rosplan_dispatch_msgs::ActionFeedback>("/kcl_rosplan/action_feedback", 5, /* latch */ false);
 
 		// problem generation client
 		generate_problem_client = nh.serviceClient<rosplan_knowledge_msgs::GenerateProblemService>("/kcl_rosplan/generate_planning_problem");

--- a/rosplan_planning_system/src/PlanningSystem.cpp
+++ b/rosplan_planning_system/src/PlanningSystem.cpp
@@ -367,6 +367,7 @@ namespace KCL_rosplan {
 			statusMsg.data = "Dispatching";
 			state_publisher.publish(statusMsg);
 			plan_start_time = ros::WallTime::now().toSec();
+			dispatch_attempts += 1;
 			planSucceeded = plan_dispatcher->dispatchPlan(plan_parser->action_list, mission_start_time, plan_start_time);
 			
 			if (!planSucceeded) {
@@ -376,6 +377,11 @@ namespace KCL_rosplan {
 			}
 		}
 		ROS_INFO("KCL: (PS) (%s) Planning System Finished", problem_name.c_str());
+
+		if (! planSucceeded && dispatch_attempts >= max_dispatch_attempts) {
+			ROS_INFO("KCL: (PS) (%s) Maximum dispatch attempts (%i) exceeded",
+			         problem_name.c_str(), max_dispatch_attempts);
+    }
 
 		system_status = READY;
 		statusMsg.data = "Ready";

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanActionDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanActionDispatcher.py
@@ -14,9 +14,13 @@ from rosplan_dispatch_msgs.msg import *
 from rosplan_knowledge_msgs.srv import *
 from rosplan_knowledge_msgs.msg import *
 
-from python_qt_binding import loadUi
+from python_qt_binding import loadUi, QT_BINDING_VERSION
 from python_qt_binding.QtCore import Qt, QTimer, Signal, Slot
-from python_qt_binding.QtGui import QHeaderView, QIcon, QTreeWidgetItem, QListWidgetItem, QComboBox, QWidget
+if QT_BINDING_VERSION.startswith('4'):
+    from python_qt_binding.QtGui import QHeaderView, QIcon, QTreeWidgetItem, QListWidgetItem, QComboBox, QWidget
+else:
+    from python_qt_binding.QtWidgets import QHeaderView, QTreeWidgetItem, QListWidgetItem, QComboBox, QWidget
+    from python_qt_binding.QtGui import QIcon
 
 class ActionDispatchWidget(QWidget):
 

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
@@ -14,9 +14,13 @@ from rosplan_dispatch_msgs.msg import *
 from rosplan_knowledge_msgs.srv import *
 from rosplan_knowledge_msgs.msg import *
 
-from python_qt_binding import loadUi
+from python_qt_binding import loadUi, QT_BINDING_VERSION
 from python_qt_binding.QtCore import Qt, QTimer, Signal, Slot
-from python_qt_binding.QtGui import QHeaderView, QIcon, QTreeWidgetItem, QListWidgetItem, QWidget
+if QT_BINDING_VERSION.startswith('4'):
+    from python_qt_binding.QtGui import QHeaderView, QIcon, QTreeWidgetItem, QListWidgetItem, QWidget
+else:
+    from python_qt_binding.QtWidgets import QHeaderView, QTreeWidgetItem, QListWidgetItem, QWidget
+    from python_qt_binding.QtGui import QIcon
 
 class PlanViewWidget(QWidget):
 
@@ -86,7 +90,10 @@ class PlanViewWidget(QWidget):
         self._plugin = plugin
         self.planView.sortByColumn(0, Qt.AscendingOrder)
         header = self.planView.header()
-        header.setResizeMode(QHeaderView.ResizeToContents)
+        if QT_BINDING_VERSION.startswith('4'):
+            header.setResizeMode(QHeaderView.ResizeToContents)
+        else:
+            header.setSectionResizeMode(QHeaderView.ResizeToContents)
 
         # setup plan view columns
         self._column_index = {}

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanProblemViewer.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanProblemViewer.py
@@ -14,9 +14,12 @@ from rosplan_dispatch_msgs.msg import *
 from rosplan_knowledge_msgs.srv import *
 from rosplan_knowledge_msgs.msg import *
 
-from python_qt_binding import loadUi
+from python_qt_binding import loadUi, QT_BINDING_VERSION
 from python_qt_binding.QtCore import Qt, QTimer, QUrl, Signal, Slot
-from python_qt_binding.QtGui import *
+if QT_BINDING_VERSION.startswith('4'):
+    from python_qt_binding.QtGui import  QWidget
+else:
+    from python_qt_binding.QtWidgets import QWidget
 
 class ProblemViewerWidget(QWidget):
 


### PR DESCRIPTION
This first round of changes introduces Qt5 compatibility for the rqt plugins (it should still be compatible with Qt4, but I can't test locally). Additionally, it brings a few fixes especially regarding the comparitor and case sensitivity. Also, make action dispatch topic non-latching in order to avoid that (old) actions get executed once an action interface is started.