### PR TITLE
Tool support improvements

### DIFF
--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -91,6 +91,8 @@ set(PLANNING_SOURCES
 add_executable(planner ${PLANNING_SOURCES} ${VAL_SOURCES})
 add_executable(simulatedAction src/RPSimulatedActionInterface.cpp src/RPActionInterface.cpp)
 
+add_executable(print_plan src/print_plan.cpp)
+
 ## Add dependencies
 add_dependencies(planner ${catkin_EXPORTED_TARGETS})
 add_dependencies(simulatedAction ${catkin_EXPORTED_TARGETS})
@@ -98,6 +100,7 @@ add_dependencies(simulatedAction ${catkin_EXPORTED_TARGETS})
 ## Specify libraries against which to link a library or executable target
 target_link_libraries(planner ${catkin_LIBRARIES})
 target_link_libraries(simulatedAction ${catkin_LIBRARIES})
+target_link_libraries(print_plan ${catkin_LIBRARIES})
 
 ## Declare libraries
 add_library(${PROJECT_NAME} ${PLANNING_SOURCES} ${VAL_SOURCES})

--- a/rosplan_planning_system/src/PlanningSystem.cpp
+++ b/rosplan_planning_system/src/PlanningSystem.cpp
@@ -429,6 +429,8 @@ namespace KCL_rosplan {
 			getline(planfile, line);
 			if (line.find("; Plan found", 0) != std::string::npos)
 				solved = true;
+			if (line.find("; Solution Found", 0) != std::string::npos)
+				solved = true;
 			if (line.find("ff: found", 0) != std::string::npos)
 				solved = true;
 		}

--- a/rosplan_planning_system/src/print_plan.cpp
+++ b/rosplan_planning_system/src/print_plan.cpp
@@ -1,0 +1,69 @@
+
+/***************************************************************************
+ *  print_plan.cpp - print plan as PDDL to output
+ *
+ *  Created: Wed Mar 22 14:40:56 2017
+ *  Copyright  2017  Tim Niemueller [www.niemueller.de]
+ ****************************************************************************/
+
+/*  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * - Neither the name of the authors nor the names of its contributors
+ *   may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ros/ros.h>
+#include <rosplan_dispatch_msgs/CompletePlan.h>
+
+#include <cstdio>
+
+void
+plan_cb(const rosplan_dispatch_msgs::CompletePlan::ConstPtr& msg)
+{
+	for (const auto &a : msg->plan) {
+		std::string s;
+		for (const auto &p : a.parameters) {
+			s += " " + p.value;
+		}
+		printf("%7.3f: (%s %s)  [%.3f]\n", a.dispatch_time, a.name.c_str(), s.c_str(), a.duration);
+	}
+	ros::shutdown();
+}
+
+
+
+
+int
+main(int argc, char **argv)
+{
+	ros::init(argc, argv, "rcll_refbox_peer");
+
+	ros::NodeHandle n;
+	ros::Subscriber sub_plan = n.subscribe("kcl_rosplan/plan", 1, plan_cb);
+
+	ros::spin();
+	
+	return 0;
+}

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
@@ -109,6 +109,7 @@ class PlanViewWidget(QWidget):
         rospy.Subscriber("/kcl_rosplan/plan", CompletePlan, self.plan_callback)
         rospy.Subscriber("/kcl_rosplan/action_feedback", ActionFeedback, self.action_feedback_callback)
         rospy.Subscriber("/kcl_rosplan/system_state", String, self.system_status_callback)
+        self._plan_pub = rospy.Publisher('/kcl_rosplan/planning_commands', String, queue_size=10)
 
         self.refresh_model()
 
@@ -220,24 +221,21 @@ class PlanViewWidget(QWidget):
     """
     def _handle_plan_clicked(self, checked):
         self._status_list.clear()
-        plan_pub = rospy.Publisher('/kcl_rosplan/planning_commands', String, queue_size=10)
-        plan_pub.publish('plan')
+        self._plan_pub.publish('plan')
 
     """
     called when the plan button is clicked; sends a planning request
     """
     def _handle_pause_clicked(self, checked):
         self._status_list.clear()
-        plan_pub = rospy.Publisher('/kcl_rosplan/planning_commands', String, queue_size=10)
-        plan_pub.publish('pause')
+        self._plan_pub.publish('pause')
 
     """
     called when the plan button is clicked; sends a planning request
     """
     def _handle_cancel_clicked(self, checked):
         self._status_list.clear()
-        plan_pub = rospy.Publisher('/kcl_rosplan/planning_commands', String, queue_size=10)
-        plan_pub.publish('cancel')
+        self._plan_pub.publish('cancel')
 
     """
     callback for complete_plan

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanProblemViewer.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanProblemViewer.py
@@ -15,7 +15,7 @@ from rosplan_knowledge_msgs.srv import *
 from rosplan_knowledge_msgs.msg import *
 
 from python_qt_binding import loadUi, QT_BINDING_VERSION
-from python_qt_binding.QtCore import Qt, QTimer, QUrl, Signal, Slot
+from python_qt_binding.QtCore import Qt, QTimer, QUrl, Signal, Slot, pyqtSignal
 if QT_BINDING_VERSION.startswith('4'):
     from python_qt_binding.QtGui import  QWidget
 else:
@@ -24,6 +24,7 @@ else:
 class ProblemViewerWidget(QWidget):
 
     _problem_text = ""
+    _update_signal = pyqtSignal()
 
     def __init__(self, plugin=None):
         super(ProblemViewerWidget, self).__init__()
@@ -34,25 +35,19 @@ class ProblemViewerWidget(QWidget):
         self.setObjectName('ROSPlanProblemViewer')
 
         self._plugin = plugin
-        rospy.Subscriber("/kcl_rosplan/problem", String, self.refresh_problem)
+        rospy.Subscriber("/kcl_rosplan/problem", String, self.problem_received)
 
-        # init and start update timers
-        self._timer_set_problem = QTimer(self)
-        self._timer_set_problem.timeout.connect(self.set_problem)
-
-        self.start()
-
-    def start(self):
-        self._timer_set_problem.start(1000)
+        self._update_signal.connect(self.update_problem)
 
     """
     updating problem view
     """
-    def refresh_problem(self, msg):
+    def problem_received(self, msg):
         self._problem_text = msg.data
+        self._update_signal.emit()
 
-    def set_problem(self):
-        self.textEdit.setPlainText(self._problem_text)
+    def update_problem(self):
+	    self.textEdit.setPlainText(self._problem_text)
 
     """
     Qt methods

--- a/rosplan_rqt/src/rosplan_rqt/problem_viewer.py
+++ b/rosplan_rqt/src/rosplan_rqt/problem_viewer.py
@@ -10,7 +10,6 @@ class ROSPlanProblemViewer(Plugin):
 
         self._widget = ProblemViewerWidget(self)
 
-        self._widget.start()
         if context.serial_number() > 1:
             self._widget.setWindowTitle(self._widget.windowTitle() + (' (%d)' % context.serial_number()))
         context.add_widget(self._widget)


### PR DESCRIPTION
The one functional change is to allow popf in "one-shot" mode, i.e., without the "-n" flag. The output is different in that case and we must adapt the "parser" (we really need to get going on libpddl @m312z ). This solving mode can have advantages:
- once a solution is found, us it immediately (beneficial if planning time is below the set timeout to start execution earlier)
- do not set a deadline for finding a solution (for harder problems, rather than failing we just want to keep searching)

The rqt changes fix some annoyances. The print_plan is a little tool that allows to print a plan as PDDL off of the ROS topic. This representation can be more convenient to feed another tool or to just read over the produced plan without a GUI.