### PR TITLE
Permit negated facts

### DIFF
--- a/rosplan_planning_system/src/ProblemGeneration/PDDLProblemGenerator.cpp
+++ b/rosplan_planning_system/src/ProblemGeneration/PDDLProblemGenerator.cpp
@@ -48,14 +48,11 @@ namespace KCL_rosplan {
 	/*---------------*/
 
 	void PDDLProblemGenerator::makeInitialState(PlanningEnvironment environment, std::ofstream &pFile) {
-        bool is_negated = false;
-
 		pFile << "(:init" << std::endl;
 
 		// add knowledge to the initial state
 		for(size_t i=0; i<environment.domain_attributes.size(); i++) {
 
-            is_negated = false;			
 			std::stringstream ss;			
 			ss << "    (";
 
@@ -66,7 +63,6 @@ namespace KCL_rosplan {
             
             //Check if the attribute is negated
             if(environment.domain_attributes[i].is_negative){
-                is_negated = true;
                 ss << "not (";
             }
 
@@ -99,7 +95,7 @@ namespace KCL_rosplan {
 			};
 			ss << ")";
 
-            if(is_negated)
+            if(environment.domain_attributes[i].is_negative)
                 ss << ")";
 
 			// output function value

--- a/rosplan_planning_system/src/ProblemGeneration/PDDLProblemGenerator.cpp
+++ b/rosplan_planning_system/src/ProblemGeneration/PDDLProblemGenerator.cpp
@@ -48,12 +48,14 @@ namespace KCL_rosplan {
 	/*---------------*/
 
 	void PDDLProblemGenerator::makeInitialState(PlanningEnvironment environment, std::ofstream &pFile) {
+        bool is_negated = false;
 
 		pFile << "(:init" << std::endl;
 
 		// add knowledge to the initial state
 		for(size_t i=0; i<environment.domain_attributes.size(); i++) {
-			
+
+            is_negated = false;			
 			std::stringstream ss;			
 			ss << "    (";
 
@@ -61,6 +63,12 @@ namespace KCL_rosplan {
 			if(environment.domain_attributes[i].knowledge_type == rosplan_knowledge_msgs::KnowledgeItem::FUNCTION) {
 				ss << "= (";
 			};
+            
+            //Check if the attribute is negated
+            if(environment.domain_attributes[i].is_negative){
+                is_negated = true;
+                ss << "not (";
+            }
 
 			ss << environment.domain_attributes[i].attribute_name;
 			
@@ -81,7 +89,7 @@ namespace KCL_rosplan {
 				for(size_t k=0; k<environment.domain_attributes[i].values.size(); k++) {
 					if(0 == environment.domain_attributes[i].values[k].key.compare(ait->second[j])) {
 						ss << " " << environment.domain_attributes[i].values[k].value;
-						found = true;
+                        found = true;
 					}
 				}
 				if(!found)
@@ -90,6 +98,9 @@ namespace KCL_rosplan {
 				}
 			};
 			ss << ")";
+
+            if(is_negated)
+                ss << ")";
 
 			// output function value
 			if(environment.domain_attributes[i].knowledge_type == rosplan_knowledge_msgs::KnowledgeItem::FUNCTION) {

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
@@ -154,11 +154,16 @@ class PlanViewWidget(QWidget):
             self.modelView.clear()
             self._fact_list.clear()
             for attribute in resp.attributes:
+                attributeText = ''
                 item = QListWidgetItem(self.modelView)
-                attributeText = '(' + attribute.attribute_name
+                if attribute.is_negative:
+                    attributeText = '(not '
+                attributeText = attributeText + '(' + attribute.attribute_name
                 for keyval in attribute.values:
                      attributeText = attributeText + ' ' + keyval.value
                 attributeText = attributeText + ')'
+                if attribute.is_negative:
+                    attributeText = attributeText + ')'
                 item.setText(attributeText)
                 self._fact_list[attributeText] = attribute
                 if attributeText in selected_list:


### PR DESCRIPTION
The knowledge base allows for facts to be negated through the is_negative flag. However, problem generation does not account for the negation and creates initial state that is always positive (but not always true).

Further, the rqt problem dispatcher also ignored the is_negative flag and did not display the negative for negated facts. This gets impossibly confusing for a large knowledge base.

This fixes both of the above issues.