### PR TITLE
Build system fixes

### DIFF
--- a/rosplan_interface_mapping/CMakeLists.txt
+++ b/rosplan_interface_mapping/CMakeLists.txt
@@ -68,3 +68,12 @@ target_link_libraries(rpsimplemapServer ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 # please do not use add_rosttest_gtest (seems to be interfering with qtcreator and cmake)
 
+#############
+## Install ##
+#############
+
+install(TARGETS rproadmapServer rpsimplemapServer
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/rosplan_interface_movebase/CMakeLists.txt
+++ b/rosplan_interface_movebase/CMakeLists.txt
@@ -48,3 +48,13 @@ add_dependencies(rpmovebase ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries against which to link a library or executable target
 target_link_libraries(rpmovebase ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+#############
+## Install ##
+#############
+
+install(TARGETS rpmovebase
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/rosplan_knowledge_base/CMakeLists.txt
+++ b/rosplan_knowledge_base/CMakeLists.txt
@@ -97,3 +97,13 @@ target_link_libraries(knowledgeBase ${catkin_LIBRARIES})
 ##########
 
 # please do not use add_rosttest_gtest (seems to be interfering with qtcreator and cmake)
+
+#############
+## Install ##
+#############
+
+install(TARGETS knowledgeBase
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -90,16 +90,17 @@ set(PLANNING_SOURCES
 ## Declare cpp executables
 add_executable(planner ${PLANNING_SOURCES} ${VAL_SOURCES})
 add_executable(simulatedAction src/RPSimulatedActionInterface.cpp src/RPActionInterface.cpp)
-## add_executable(print_plan src/print_plan.cpp)
+add_executable(print_plan src/print_plan.cpp)
 
 ## Add dependencies
 add_dependencies(planner ${catkin_EXPORTED_TARGETS})
 add_dependencies(simulatedAction ${catkin_EXPORTED_TARGETS})
+add_dependencies(print_plan ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries against which to link a library or executable target
 target_link_libraries(planner ${catkin_LIBRARIES})
 target_link_libraries(simulatedAction ${catkin_LIBRARIES})
-## target_link_libraries(print_plan ${catkin_LIBRARIES})
+target_link_libraries(print_plan ${catkin_LIBRARIES})
 
 ## Declare libraries
 add_library(${PROJECT_NAME} ${PLANNING_SOURCES} ${VAL_SOURCES})

--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -35,6 +35,9 @@ include_directories(src/VALfiles)
 
 find_package(FLEX REQUIRED)
 
+# Disable deprecated declarations warning (about std::auto_ptr)
+add_definitions(-Wno-deprecated-declarations)
+
 ## visualisation
 find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)

--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -135,3 +135,14 @@ install(DIRECTORY src/VALfiles/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
+
+# This should probably go to the package bin directory,
+# but there is no simple way to determine this path from
+# within a launch file similar to "$(find ...)".
+# The chosen path allows to use the same roslaunch parameter,
+# when run from the workspace or when installed.
+file(GLOB COMMON_BINS common/bin/*)
+install(PROGRAMS ${COMMON_BINS}
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/common/bin
+)
+

--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -112,7 +112,7 @@ add_dependencies(rosplan_action_interface ${catkin_EXPORTED_TARGETS})
 ## Install ##
 #############
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} rosplan_action_interface planner print_plan simulatedAction
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -120,6 +120,11 @@ install(TARGETS ${PROJECT_NAME}
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  PATTERN ".svn" EXCLUDE
+)
+
+install(DIRECTORY include/rosplan_action_interface
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
   PATTERN ".svn" EXCLUDE
 )
 

--- a/rosplan_rqt/CMakeLists.txt
+++ b/rosplan_rqt/CMakeLists.txt
@@ -3,3 +3,12 @@ project(rosplan_rqt)
 
 find_package(catkin REQUIRED)
 catkin_package()
+catkin_python_setup()
+
+install(FILES plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY resource
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/rosplan_rqt/setup.py
+++ b/rosplan_rqt/setup.py
@@ -1,0 +1,12 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['rosplan_rqt'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)
+


### PR DESCRIPTION
This pull request fixes issues in several build system related files, especially regarding missing install target statements. It also fixes the missing dependencies statement of print_plan that broke builds. It also mutes the annoying warnings about std::auto_ptr (until Val has been fixed when or when that finally becomes an error).