### PR TITLE
Minor Change in Parameter Extraction on Parameters

### DIFF
--- a/rosplan_planning_system/src/PlanParsing/CFFPlanParser.cpp
+++ b/rosplan_planning_system/src/PlanParsing/CFFPlanParser.cpp
@@ -159,28 +159,22 @@ namespace KCL_rosplan {
 				while(!finished && !infile.eof()) {
 					for(std::string::iterator it = params.begin(); it != params.end(); ++it) {
 						switch (state) {
-						case 0: // reading parameter
-							if (*it == '-' || *it == ' ') {
-								// std::cout << params.substr(count_start,count_length) << std::endl;
-								operator_parameter_map[action_name].push_back(params.substr(count_start,count_length));
+							case 0://looking for predicate started with ?
+							if (*it == '?') {
+								count_start = count_start + count_length;
+								count_length = 0;
 								state++;
 							}
 							break;
-						case 1: // skipping " - "
-							if (*it != '-' && *it != ' ') state++;
-							break;
-						case 2: // skipping type
-							if (*it == ' ') state++;
-							break;
-						case 3: // skipping spaces
-							if (*it != ' ') {
-								count_start = count_start + count_length;
-								count_length = 0;
-								state = 0;
+							
+							case 1://getting predicate
+							if (*it == ' ' || *it == ')') {
+								operator_parameter_map[action_name].push_back(params.substr(count_start,count_length));
+								state =0;
 							}
 							break;
 						}
-
+						
 						count_length++;
 
 						if (*it == ')') {


### PR DESCRIPTION
This is a minor modification to the CFFPlanParser to include more general cases covered by PDDL 2.1. The planner was able to give a valid plan but the parser would not work correctly. The earliest version identifies the parameter by locating its type. So it always should have a type after every parameter, in other to work. 
For example it would work in:
:parameters (?q - robot ?wayp - waypoint ?wayp2 - waypoint )

But not in:
:parameters (?q - robot ?wayp ?wayp2 - waypoint )   or   :parameters (?q ?wayp ?wayp2) 

The proposed version uses the same original structure but identify the parameter by locating the "?"