### PR TITLE
OverAll, atAtart and atEnd active check in durative actions. 

### DIFF
--- a/rosplan_planning_system/include/rosplan_action_interface/RPActionInterface.h
+++ b/rosplan_planning_system/include/rosplan_action_interface/RPActionInterface.h
@@ -6,6 +6,7 @@
 #include "rosplan_knowledge_msgs/DomainFormula.h"
 #include "rosplan_knowledge_msgs/KnowledgeItem.h"
 #include "rosplan_knowledge_msgs/KnowledgeUpdateService.h"
+#include "rosplan_knowledge_msgs/KnowledgeQueryService.h"
 #include "rosplan_knowledge_msgs/GetDomainOperatorDetailsService.h"
 #include "rosplan_knowledge_msgs/GetDomainPredicateDetailsService.h"
 #include "diagnostic_msgs/KeyValue.h"
@@ -28,6 +29,11 @@ namespace KCL_rosplan {
 
 	protected:
 
+		bool checkConditions(const std::vector<rosplan_knowledge_msgs::DomainFormula>& df, const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg, bool positive = true);
+		bool checkAtStartConditions(const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg);
+		bool checkAtEndConditions(const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg);
+		bool checkOverAllConditions(const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg);
+
 		/* PDDL info and publisher */
 		std::map<std::string, rosplan_knowledge_msgs::DomainFormula> predicates;
 		rosplan_knowledge_msgs::DomainFormula params;
@@ -39,6 +45,7 @@ namespace KCL_rosplan {
 
 		/* service handle to PDDL knowledge base */
 		ros::ServiceClient update_knowledge_client;
+		ros::ServiceClient query_knowledge_client;
 
 		/* action status */
 		bool action_success;
@@ -50,7 +57,7 @@ namespace KCL_rosplan {
 
 		/* listen to and process action_dispatch topic */
 		void dispatchCallback(const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg);
-		
+
 		/* perform or call real action implementation */
 		virtual bool concreteCallback(const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg) =0;
 	};

--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
@@ -115,7 +115,7 @@ class PlanViewWidget(QWidget):
 
     def start(self):
         self._timer_refresh_plan.start(1000)
-        self._timer_refresh_goals.start(10000)
+        self._timer_refresh_goals.start(1000)
 
     """
     updating goal and model view
@@ -355,7 +355,7 @@ class PlanViewWidget(QWidget):
 
     """
     Qt methods
-    """ 
+    """
     def shutdown_plugin(self):
         pass
 

--- a/rosplan_rqt/src/rosplan_rqt/graphUpdater.py
+++ b/rosplan_rqt/src/rosplan_rqt/graphUpdater.py
@@ -44,7 +44,7 @@ class PlanViewWidget:
 
     def start(self):
         self._timer_refresh_plan.start(1000)
-        self._timer_refresh_goals.start(10000)
+        self._timer_refresh_goals.start(1000)
 
     """
     updating plan view


### PR DESCRIPTION
I detected a problem when I used ROSPlan: In durative actions, the over_all, at_start and at_end conditions were not checked anywhere.

I have made added functions to do this in RPActionInterface. Now you can do something like:

```
bool RP_myaction_doctor::concreteCallback(const rosplan_dispatch_msgs::ActionDispatch::ConstPtr& msg)
{
	if(!checkAtStartConditions(msg))
	{
		ROS_ERROR("AT Start not meet: cancelling");
		return false;
	}
	bool finished = false;
	ros::Rate rate(1);
	int counter=0;
	while(ros::ok() && !finished)
	{
		if(!checkOverAllConditions(msg))
		{
			ROS_ERROR("ALL OVER not meet: cancelling");
			return false;
		}
		if(counter == 5) //My stuff
		{
			finished = true;
		}
		counter++;
		ros::spinOnce();
		rate.sleep();
	}
	if(!checkAtEndConditions(msg))
	{
		ROS_ERROR("AT END not meet: cancelling");
		return false;
	}
	ROS_INFO("My action Done!!!");
	return true;
}
```