### PR TITLE
[rosplan_knowledge_base] fix KB node consuming 100 percent cpu

### DIFF
--- a/rosplan_knowledge_base/src/KnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/KnowledgeBase.cpp
@@ -8,7 +8,7 @@ namespace KCL_rosplan {
 	void KnowledgeBase::runKnowledgeBase() {
 
         // loop
-        //ros::Rate loopRate(5);
+        ros::Rate loopRate(5);
 		while(ros::ok()) {
 
 			// update TILs
@@ -28,7 +28,7 @@ namespace KCL_rosplan {
 			}
 
 			// services
-            //loopRate.sleep();
+            loopRate.sleep();
             ros::spinOnce();
 		}
 	}


### PR DESCRIPTION
KB node is currently consuming 100 percent cpu, this pull request uncomments some lines of code that were there already but for some reason were commented out