### PR TITLE
[rosplan_rqt, ROSPlanDispatcher] provide feedback to user in case KB …

### DIFF
--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanDispatcher.py
@@ -44,9 +44,11 @@ class PlanViewWidget(QWidget):
         loadUi(ui_file, self)
         self.setObjectName('ROSPlanDispatcherUI')
 
+        rospy.loginfo('Waiting for rosplan_knowledge_base services to become available (5 sec timeout)')
+
         # populate goal combo boxes
-        rospy.wait_for_service('rosplan_knowledge_base/domain/predicates')
         try:
+            rospy.wait_for_service('rosplan_knowledge_base/domain/predicates', 5.0)
             predicates_client = rospy.ServiceProxy('rosplan_knowledge_base/domain/predicates', GetDomainAttributeService)
             resp = predicates_client()
             for pred in resp.items:


### PR DESCRIPTION
if you launch rosplan rqt action dispatcher without KB it just freezes and does not show gui interface, this can be confusing to user, this commit provides with a timeout and a message to the user to remind him he forgot to run the Knowledge base