### PR TITLE
[rosplan_demos] turtlebot_explore.bash remove goal visited wp0, turtl…

### DIFF
--- a/rosplan_demos/scripts/turtlebot_explore.bash
+++ b/rosplan_demos/scripts/turtlebot_explore.bash
@@ -12,7 +12,7 @@ param="knowledge:
   instance_name: 'kenny'
   attribute_name: ''
   function_value: 0.0";
-for i in $(seq 0 $(( $(rosservice call /rosplan_knowledge_base/state/instances "type_name: 'waypoint'" | sed 's/wp/\n/g' | wc -l) - 2)) )
+for i in $(seq 1 $(( $(rosservice call /rosplan_knowledge_base/state/instances "type_name: 'waypoint'" | sed 's/wp/\n/g' | wc -l) - 2)) )
 do
 param_type="$param_type
 - 1"


### PR DESCRIPTION
to workaround #136, this PR just removes the goal to visit wp0, since the robot starts from there