### PR TITLE
Exogenous action

### DIFF
--- a/rosplan_knowledge_base/src/RDDLKnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/RDDLKnowledgeBase.cpp
@@ -104,6 +104,13 @@ namespace KCL_rosplan {
 
             res.operators.push_back(formula);
         }
+
+        // Add exogenous operator
+        rosplan_knowledge_msgs::DomainFormula formula;
+        formula.name = "exogenous";
+        // FIXME parameters?
+        res.operators.push_back(formula);
+
         return true;
     }
 
@@ -134,6 +141,17 @@ namespace KCL_rosplan {
             // Compute assign effects
             res.op.at_end_assign_effects = RDDLUtils::getOperatorAssignEffects(res.op.formula,
                                                                                        domain_parser.rddlTask->CPFDefinitions);
+            return true;
+        }
+        if (req.name == "exogenous") {
+            // operator name
+            res.op.formula.name = req.name;
+
+            // Compute effects
+            EffectDomainFormula eff = RDDLUtils::getOperatorEffects(res.op.formula, domain_parser.rddlTask->CPFDefinitions);
+            res.op.at_end_add_effects = eff.add;
+            res.op.at_end_del_effects = eff.del;
+            res.op.probabilistic_effects = eff.prob;
             return true;
         }
         return false;

--- a/rosplan_knowledge_base/src/RDDLUtils.cpp
+++ b/rosplan_knowledge_base/src/RDDLUtils.cpp
@@ -183,7 +183,9 @@ namespace KCL_rosplan {
             std::map<std::string, std::string> assign; // Replacement for each parameter of the cpd to the parameter of the action as defined in the operator header op_head
             bool action_found = false;
             EffectDomainFormula eff_i = getOperatorEffects(op_head, it->first, it->second, assign, action_found);
-            if (not action_found) continue;
+            if (not action_found and op_head.name != "exogenous") { // If an action fluent was found, it will return empty lists so it means it was an exogenous event.
+                continue;
+            }
             join(eff_ret, eff_i);
         }
         return eff_ret;

--- a/rosplan_planning_system/src/ProblemGeneration/RDDLProblemGenerator.cpp
+++ b/rosplan_planning_system/src/ProblemGeneration/RDDLProblemGenerator.cpp
@@ -152,7 +152,20 @@ namespace KCL_rosplan {
                          it != op_srv.response.op.at_end_assign_effects.end(); ++it) {
                         found_fluents.insert(it->LHS.name);
                     }
-
+                    for (size_t i = 0; i < op_srv.response.op.probabilistic_effects.size(); ++i) {
+                        for (auto it = op_srv.response.op.probabilistic_effects[i].add_effects.begin();
+                             it != op_srv.response.op.probabilistic_effects[i].add_effects.end(); ++it) {
+                            found_fluents.insert(it->name);
+                        }
+                        for (auto it = op_srv.response.op.probabilistic_effects[i].del_effects.begin();
+                             it != op_srv.response.op.probabilistic_effects[i].del_effects.end(); ++it) {
+                            found_fluents.insert(it->name);
+                        }
+                        for (auto it = op_srv.response.op.probabilistic_effects[i].assign_effects.begin();
+                             it != op_srv.response.op.probabilistic_effects[i].assign_effects.end(); ++it) {
+                            found_fluents.insert(it->LHS.name);
+                        }
+                    }
                 }
             }
             // Check if the predicate appears in any of the effect lists


### PR DESCRIPTION
Added exogenous action in RDDL that represents exogenous effects from the domain. It is useful for the problem generator to know which fluents are state-fluents and which are non-fluents.