### PR TITLE
[esterel plan dispatch] add option to visualize esterel graph edges i…

### DIFF
--- a/rosplan_dispatch_msgs/msg/EsterelPlanEdge.msg
+++ b/rosplan_dispatch_msgs/msg/EsterelPlanEdge.msg
@@ -1,4 +1,10 @@
 #EsterelPlanEdge message
+
+byte CONDITION_EDGE   = 0
+byte START_END_ACTION_EDGE = 1
+byte INTERFERENCE_EDGE = 2
+
+byte edge_type
 int32 edge_id
 string edge_name
 int32 signal_type

--- a/rosplan_planning_system/include/rosplan_planning_system/PlanDispatch/EsterelPlanDispatcher.h
+++ b/rosplan_planning_system/include/rosplan_planning_system/PlanDispatch/EsterelPlanDispatcher.h
@@ -59,6 +59,8 @@ namespace KCL_rosplan
 		ros::ServiceClient query_knowledge_client;
 		ros::ServiceClient query_domain_client;
 
+		bool display_edge_type_;
+
 	public:
 
 		/* constructor */

--- a/rosplan_planning_system/include/rosplan_planning_system/PlanParsing/PDDLEsterelPlanParser.h
+++ b/rosplan_planning_system/include/rosplan_planning_system/PlanParsing/PDDLEsterelPlanParser.h
@@ -93,9 +93,9 @@ namespace KCL_rosplan {
 		/* GRAPH METHODS */
 		/*---------------*/
 
-		void makeEdge(int source_node_id, int sink_node_id) {
+		void makeEdge(int source_node_id, int sink_node_id, int edge_type) {
 			// create an ordering that only specifies after
-			makeEdge(source_node_id, sink_node_id, 0, std::numeric_limits<double>::max());
+			makeEdge(source_node_id, sink_node_id, 0, std::numeric_limits<double>::max(), edge_type);
 		}
 
 		/**
@@ -202,7 +202,7 @@ namespace KCL_rosplan {
 		void fetchTILs();
 		void createGraph();
 		bool addInterferenceEdges(std::multimap<double,int> &node_map, std::multimap<double,int>::iterator &current_node);
-		void makeEdge(int source_node_id, int sink_node_id, double lower_bound, double upper_bound);
+		void makeEdge(int source_node_id, int sink_node_id, double lower_bound, double upper_bound, int edge_type);
 		bool addConditionEdge(
 				std::multimap<double,int> &node_map, std::multimap<double,int>::iterator &current_node,
 				rosplan_knowledge_msgs::DomainFormula &condition, bool negative_condition, bool overall_condition);

--- a/rosplan_planning_system/launch/includes/dispatch_interface.launch
+++ b/rosplan_planning_system/launch/includes/dispatch_interface.launch
@@ -7,6 +7,8 @@
 	<arg name="plan_topic"               default="/rosplan_parsing_interface/complete_plan" />
 	<arg name="action_dispatch_topic"    default="action_dispatch" />
 	<arg name="action_feedback_topic"    default="action_feedback" />
+	<!-- visualize edges with colors: interference edge, conditional edge, etc -->
+	<arg name="display_edge_type"        default="false" />
 
 
 	<!-- plan dispatching -->
@@ -15,6 +17,7 @@
 		<param name="plan_topic"            value="$(arg plan_topic)" />
 		<param name="action_dispatch_topic" value="$(arg action_dispatch_topic)" />
 		<param name="action_feedback_topic" value="$(arg action_feedback_topic)" />
+		<param name="display_edge_type"     value="$(arg display_edge_type)" />
 	</node>
 
 </launch>


### PR DESCRIPTION
1. add option to display edges in colors:
red - plan start to end edge
green - conditional edge
blue - interference edge
default behavior is all edges are black but parameter can be activated in launch file to activate edge color for debugging purposes. It is recommended that if user is executing the plan in an actual
robot this flag to be off because the dispatcher colors active action edges in red.
---
2. display action parameters in esterel graph: it is hard to figure out what is going on during
plan execution, therefore I propose to by default show to user action plan parameters as
part of esterel graph