### PR TITLE
[PDDLEsterelPlanParser] add esterel graph edge pruning optimization b…

### DIFF
--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -46,6 +46,9 @@ find_package(OpenGL REQUIRED)
 find_package(GLUT REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS})
 
+## Libraries
+add_library(floyd_warshall src/PlanParsing/floyd_warshall.cpp)
+
 ## Declare cpp executables
 add_executable(problemInterface src/ProblemGeneration/ProblemInterface.cpp src/ProblemGeneration/PDDLProblemGenerator.cpp
                                                                            src/ProblemGeneration/ProblemGenerator.cpp
@@ -103,7 +106,7 @@ target_link_libraries(upm_planner_interface ${catkin_LIBRARIES})
 target_link_libraries(pprp_planner_interface ${catkin_LIBRARIES})
 target_link_libraries(online_planner_interface ${catkin_LIBRARIES})
 target_link_libraries(pddl_simple_plan_parser ${catkin_LIBRARIES})
-target_link_libraries(pddl_esterel_plan_parser ${catkin_LIBRARIES})
+target_link_libraries(pddl_esterel_plan_parser ${catkin_LIBRARIES} floyd_warshall)
 target_link_libraries(pddl_simple_plan_dispatcher ${catkin_LIBRARIES})
 target_link_libraries(pddl_esterel_plan_dispatcher ${catkin_LIBRARIES})
 target_link_libraries(online_plan_dispatcher ${catkin_LIBRARIES})

--- a/rosplan_planning_system/include/rosplan_planning_system/PlanParsing/PDDLEsterelPlanParser.h
+++ b/rosplan_planning_system/include/rosplan_planning_system/PlanParsing/PDDLEsterelPlanParser.h
@@ -8,6 +8,7 @@
 #include "rosplan_knowledge_msgs/DomainOperator.h"
 #include "rosplan_knowledge_msgs/DomainFormula.h"
 #include "diagnostic_msgs/KeyValue.h"
+#include "rosplan_planning_system/PlanParsing/floyd_warshall.h"
 
 #include <stdlib.h>
 #include <string>
@@ -159,6 +160,12 @@ namespace KCL_rosplan {
 		ros::ServiceClient get_functions_client;
 		ros::ServiceClient get_operator_details_client;
 		std::multimap<double, rosplan_knowledge_msgs::KnowledgeItem> til_list;
+
+		// class used to check for node connectivity in a directed graph
+		floydWarshall graph_as_matrix_;
+
+		// update distance matrix every time an interference edge is added
+		bool strong_graph_optimization_;
 
 	protected:
 

--- a/rosplan_planning_system/include/rosplan_planning_system/PlanParsing/floyd_warshall.h
+++ b/rosplan_planning_system/include/rosplan_planning_system/PlanParsing/floyd_warshall.h
@@ -1,0 +1,94 @@
+/**
+ * Author: Oscar Lima (olima_84@yahoo.com)
+ *
+ * Floy-Warshall algorithm for computing minimum distance between nodes in a directed graph
+ *
+ * code partially reused from: https://www.geeksforgeeks.org/floyd-warshall-algorithm-dp-16/
+ */
+
+#include <iostream>
+#include <stdio.h>
+#include <vector>
+#include <limits>
+#include <stdexcept>
+
+class floydWarshall
+{
+  public:
+	/**
+	 * @brief empty constructor, relies on setDistanceMatrix(args) function to be called first
+	 */
+	floydWarshall();
+
+	/**
+	 * @brief overloaded constructor, allows to set graph at object creation
+	 * @param graph 2D matrix that contains the graph connectivity
+	 */
+	floydWarshall(std::vector<std::vector<double> > &graph);
+
+	/**
+	 * @brief input the graph to the class, will be used as initial distance matrix
+	 * saves graph to member variable for future use
+	 */
+	void setDistanceMatrix(std::vector<std::vector<double> > &graph);
+
+	/**
+	 * @brief Solves the all-pairs shortest path problem using Floyd Warshall algorithm
+	 * @return true if algorithm found solution, false if there was an error
+	 */
+	bool updateDistanceMatrix();
+
+	/**
+	 * @brief make empty matrix of nxn and fill it diagonally with 0's, upper and lower triangle with inf
+	 * @param number_of_nodes the size of the square (minimum distance / connectivity) graph matrix
+	 */
+	void setEmptyDistanceMatrix(int number_of_nodes);
+
+	/**
+	 * @brief helper function to determine if two nodes are connected in a directed graph
+	 * based on the minimum distance matrix (needs to be updated so call updateDistanceMatrix first)
+	 * @param source_node_id the start node from which the path is analyzed
+	 * @param sink_node_id the end node in which the path ends
+	 * @return true if there is a combination of directed edges that connects them trough a path
+	 * false otherwise
+	 */
+	bool connectedSingleQuery(int source_node_id, int sink_node_id);
+
+	/**
+	 * @brief based on existance matrix is easy to check if there is already an edge in the graph
+	 * this function however is valid only before calling updateDistanceMatrix
+	 * @param source_node_id the parent node from which the edge is coming from
+	 * @param sink_node_id the child node to which the edge is going
+	 * @return true if edge between nodes exist, false otherwise
+	 */
+	bool checkEdgeExistance(int source_node_id, int sink_node_id);
+
+	/**
+	 * @brief helper function useful to create graph incrementally (add edges one by one)
+	 * @param source_node_id the id of the node from which the edge is comming from
+	 * @param sink_node_id the id of the node to wich the edge is going to
+	 * @param weight the weight of the directed edge
+	 * @return true if the edge was created, false if the edge existed previously : edge will not be created
+	 */
+	bool makeNonDuplicateEdge(int source_node_id, int sink_node_id, double weight);
+
+	/**
+	 * @brief Sample function for debugging purposes that allows to print distance_matrix_[][]
+	 * @return void, this funciton prints to console
+	 */
+	void printMatrix();
+
+  private:
+
+	// flag to indicate floyd warshall algorithm is ready to be computed
+	bool init_;
+
+	// flag to indicate if checkEdgeExistance function is valid or not
+	bool distance_matrix_updated_once_;
+
+	// the number of nodes in the directed graph
+	int number_of_nodes_;
+
+	// graph as matrix, which will be converted later into distance matrix
+	std::vector<std::vector<double> > distance_matrix_;
+};

--- a/rosplan_planning_system/launch/includes/parsing_interface.launch
+++ b/rosplan_planning_system/launch/includes/parsing_interface.launch
@@ -6,6 +6,7 @@
 	<arg name="knowledge_base"   default="rosplan_knowledge_base" />
 	<arg name="planner_topic"    default="/rosplan_planner_interface/planner_output" />
 	<arg name="plan_topic"       default="complete_plan" />
+	<arg name="strong_graph_optimization" default="false" />
 
 
 	<!-- plan parsing -->
@@ -13,6 +14,7 @@
 		<param name="knowledge_base" value="$(arg knowledge_base)" />
 		<param name="planner_topic"  value="$(arg planner_topic)" />
 		<param name="plan_topic"     value="$(arg plan_topic)" />
+		<param name="strong_graph_optimization" value="$(arg strong_graph_optimization)" />
 	</node>
 
 </launch>

--- a/rosplan_planning_system/src/PlanParsing/floyd_warshall.cpp
+++ b/rosplan_planning_system/src/PlanParsing/floyd_warshall.cpp
@@ -1,0 +1,239 @@
+/**
+ * Author: Oscar Lima (olima_84@yahoo.com)
+ *
+ * Floy-Warshall algorithm for computing minimum distance_matrix_ance between nodes in a directed graph
+ *
+ * code partially reused from: https://www.geeksforgeeks.org/floyd-warshall-algorithm-dp-16/
+ */
+
+#include "rosplan_planning_system/PlanParsing/floyd_warshall.h"
+
+floydWarshall::floydWarshall(): number_of_nodes_(-1), init_(false), distance_matrix_updated_once_(false) {}
+
+floydWarshall::floydWarshall(std::vector<std::vector<double> > &graph): number_of_nodes_(-1), init_(false),
+distance_matrix_updated_once_(false) {
+
+	setDistanceMatrix(graph);
+}
+
+void floydWarshall::setDistanceMatrix(std::vector<std::vector<double> > &graph) {
+
+	// save initial graph in member variable for future use
+	distance_matrix_ = graph;
+
+	// get length of square matrix
+	number_of_nodes_ = distance_matrix_[0].size();
+
+	// all set, ready to compute floyd warshall
+	init_ = true;
+}
+
+bool floydWarshall::updateDistanceMatrix() {
+
+	// number of nodes not set
+	if(!init_) {
+		std::cerr << "error: graph not set, please call setDistanceMatrix(args) function before updateDistanceMatrix(args)" << std::endl;
+		return false;
+	}
+
+	/* Add all vertices one by one to the set of intermediate vertices.
+	---> Before start of an iteration, we have shortest distance_matrix_ances between all
+	pairs of vertices such that the shortest distance_matrix_ances consider only the
+	vertices in set {0, 1, 2, .. k-1} as intermediate vertices.
+	----> After the end of an iteration, vertex no. k is added to the set of
+	intermediate vertices and the set becomes {0, 1, 2, .. k} */
+	for (size_t k = 0; k < number_of_nodes_; k++) {
+		// Pick all vertices as source one by one
+		for (size_t i = 0; i < number_of_nodes_; i++) {
+			// Pick all vertices as destination for the
+			// above picked source
+			for (size_t j = 0; j < number_of_nodes_; j++) {
+				// If vertex k is on the shortest path from
+				// i to j, then update the value of distance_matrix_[i][j]
+				if (distance_matrix_[i][k] + distance_matrix_[k][j] < distance_matrix_[i][j])
+					distance_matrix_[i][j] = distance_matrix_[i][k] + distance_matrix_[k][j];
+			}
+		}
+	}
+
+	return true;
+}
+
+void floydWarshall::setEmptyDistanceMatrix(int number_of_nodes) {
+
+	number_of_nodes_ = number_of_nodes;
+
+	// remove old data if any
+	distance_matrix_.clear();
+
+	// lower flag, empty matrix is not updated
+	distance_matrix_updated_once_ = false;
+
+	// grow initial matrix to the value of number of nodes
+	distance_matrix_.resize(number_of_nodes_);
+
+	// resize distance_matrix_ std vector to number_of_nodes
+	distance_matrix_.resize(number_of_nodes_);
+	for (size_t i = 0; i < number_of_nodes_; i++)
+		distance_matrix_[i].resize(number_of_nodes_);
+
+	// init all nodes to inf, and those which are equal to itself to 0
+	for (size_t i = 0; i < number_of_nodes_; i++) {
+		for(size_t j = 0; j < number_of_nodes_; j++) {
+			if(i == j)
+				distance_matrix_[i][j] = 0;
+			else
+				distance_matrix_[i][j] = std::numeric_limits<double>::max();
+		}
+	}
+
+	// all set, now you have an empty graph, ready to be filled incrementally
+	init_ = true;
+}
+
+bool floydWarshall::connectedSingleQuery(int source_node_id, int sink_node_id) {
+
+	// number of nodes not set
+	if(!init_) {
+		std::cerr << "error: graph not set, please call setDistanceMatrix(args) function before updateDistanceMatrix(args)" << std::endl;
+		return false;
+	}
+
+	if(distance_matrix_[source_node_id][sink_node_id] < std::numeric_limits<double>::max())
+		return true;
+	else
+		return false;
+}
+
+void floydWarshall::printMatrix() {
+
+	std::cout << "The following matrix shows the shortest distances in the graph"
+		 << " between every pair of vertices" << std::endl;
+
+	for (size_t i = 0; i < number_of_nodes_; i++) {
+		for (size_t j = 0; j < number_of_nodes_; j++) {
+			if (distance_matrix_[i][j] == std::numeric_limits<double>::max())
+				printf("%7s", "inf");
+			else
+				printf ("%7.2lf", distance_matrix_[i][j]);
+		}
+		printf("\n");
+	}
+}
+
+bool floydWarshall::checkEdgeExistance(int source_node_id, int sink_node_id) {
+
+	if(distance_matrix_updated_once_) {
+		// throw exception
+		throw std::invalid_argument("checkEdgeExistance function does not work if updateDistanceMatrix was called");
+	}
+
+	if(distance_matrix_[source_node_id][sink_node_id] < std::numeric_limits<double>::max())
+		return true; // edge exists
+	else
+		return false;
+}
+
+bool floydWarshall::makeNonDuplicateEdge(int source_node_id, int sink_node_id, double weight) {
+
+	if(checkEdgeExistance(source_node_id, sink_node_id))
+		return false; // edge exists, don't add
+
+	// edge does not exist, add
+	distance_matrix_[source_node_id][sink_node_id] = weight;
+	return true;
+}
+
+void RunExample1() {
+	// this routine shows an example of how to use this class
+
+	// object creation
+	floydWarshall example_problem1;
+
+	/* Let us create the following weighted graph
+            10
+       (0)------->(3)
+        |         /|\
+      5 |          |
+        |          | 1
+       \|/         |
+       (1)------->(2)
+            3           */
+	double inf = std::numeric_limits<double>::max();
+	std::vector<std::vector<double> > graph = { {0.0, 5.0, inf, 10.0},
+												{inf, 0.0, 3.0, inf},
+												{inf, inf, 0.0, 1.0},
+												{inf, inf, inf, 0.0} };
+
+	// set graph
+	example_problem1.setDistanceMatrix(graph);
+
+	// compute floyd-Warshall to get min distance matrix
+	example_problem1.updateDistanceMatrix();
+
+	// Print the solution
+	example_problem1.printMatrix();
+
+	// check connectivity between nodes
+	int source_node_id = 1;
+	int sink_node_id = 3;
+
+	if(example_problem1.connectedSingleQuery(source_node_id, sink_node_id))
+		std::cout << "nodes " << source_node_id << " and " << sink_node_id << " are connected" << std::endl;
+	else
+		std::cout << "nodes " << source_node_id << " and " << sink_node_id << " are not connected" << std::endl;
+}
+
+void RunExample2() {
+	// this routine shows an example of how to use this class
+
+	// incremental graph update example
+
+	// object creation
+	floydWarshall example_problem2;
+
+	/* Let us create the following weighted graph incrementally
+            10
+       (0)------->(3)
+        |         /|\
+      5 |          |
+        |          | 1
+       \|/         |
+       (1)------->(2)
+            3           */
+	// create empty init matrix
+	example_problem2.setEmptyDistanceMatrix(4); // 4 nodes
+
+	// create edges incrementally
+	example_problem2.makeNonDuplicateEdge(0, 1, 5.0);
+	example_problem2.makeNonDuplicateEdge(1, 2, 3.0);
+	example_problem2.makeNonDuplicateEdge(2, 3, 1.0);
+	example_problem2.makeNonDuplicateEdge(0, 3, 10.0);
+
+	// compute floyd-Warshall to get min distance matrix
+	example_problem2.updateDistanceMatrix();
+
+	// Print the solution
+	example_problem2.printMatrix();
+
+	// check connectivity between nodes
+	int source_node_id = 1;
+	int sink_node_id = 3;
+
+	if(example_problem2.connectedSingleQuery(source_node_id, sink_node_id))
+		std::cout << "nodes " << source_node_id << " and " << sink_node_id << " are connected" << std::endl;
+	else
+		std::cout << "nodes " << source_node_id << " and " << sink_node_id << " are not connected" << std::endl;
+}
+
+int main() {
+
+	// run simple example
+	RunExample1();
+	std::cout << "-----" << std::endl;
+
+	// run incremental graph update example
+	RunExample2();
+
+	return 0;
+}


### PR DESCRIPTION
Follow up issue #140 

Add interference edge pruning esterel plan / graph optimization based on Floyd-Warshall algorithm.
There are two levels of optimization: normal and intense
The difference is whether you update the distance matrix every time you add
an interference edge or one time at the beginning only.

Here is a benchmark on problem 

P15-15-3-1-1 from mapanalyzer domain:

problem | time [s] with all floyd-warshall | time [s] with one time floyd-warshall | time [s] without floyd-warshall | with getBounds
-- | -- | -- | -- | --
P15-15-3-1-1 | 47 | 35 | 35 | 58

NOTE: with all floyd-warshall means every time we add an interference edge, we update the distance matrix (which is an expensive operation).
