### PR TITLE
fixed cpp-base64 headers not being installed

### DIFF
--- a/rosplan_dependencies/CMakeLists.txt
+++ b/rosplan_dependencies/CMakeLists.txt
@@ -274,7 +274,7 @@ install(TARGETS ippc_server
         )
 
 ## Mark cpp header files for installation
-install(DIRECTORY ippc_server/include/
+install(DIRECTORY ippc_server/include/ ippc_server/cpp-base64/
         DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
         FILES_MATCHING PATTERN "*.h"
         PATTERN ".svn" EXCLUDE)


### PR DESCRIPTION
cpp-base64 headers (base64.h) used by ippc_server were not installed by rosplan_dependencies, therefore rosplan_planning_system build fails.

I guess that hasn't been an issue, since it was falling back to using the usually available base64.h header from xmlrpcpp used by ROS core system ros_comm. But now the header from xmlrpcpp is just containing an error message, so the fallback is not working any more.
See also https://github.com/ros/ros_comm/pull/1046