### PR TITLE
remove unused OpenGL and GLUT dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install libcurl3
     - sudo apt-get install -y mongodb-server mongodb
-    - sudo apt-get install flex bison ros-kinetic-mongodb-store ros-kinetic-tf2-bullet freeglut3-dev
+    - sudo apt-get install flex bison ros-kinetic-mongodb-store ros-kinetic-tf2-bullet
     - sudo apt-get install libbdd-dev
     - git clone https://github.com/clearpathrobotics/occupancy_grid_utils
     - git submodule update --init --remote --recursive

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Get the prerequisites:
 
 (for Kinetic)
 ```sh
-sudo apt-get install flex ros-kinetic-move-base-msgs ros-kinetic-mongodb-store ros-kinetic-tf2-bullet freeglut3-dev python-catkin-tools bison libbdd-dev
+sudo apt-get install flex ros-kinetic-move-base-msgs ros-kinetic-mongodb-store ros-kinetic-tf2-bullet python-catkin-tools bison libbdd-dev
 ```
 (for Indigo)
 ```sh
-sudo apt-get install flex ros-indigo-mongodb-store ros-indigo-tf2-bullet freeglut3-dev python-catkin-tools bison libbdd-dev
+sudo apt-get install flex ros-indigo-mongodb-store ros-indigo-tf2-bullet python-catkin-tools bison libbdd-dev
 ```
 Select a catkin workspace or create a new one:
 ```sh

--- a/rosplan_planning_system/CMakeLists.txt
+++ b/rosplan_planning_system/CMakeLists.txt
@@ -41,11 +41,6 @@ find_package(FLEX REQUIRED)
 # Disable deprecated declarations warning (about std::auto_ptr)
 add_definitions(-Wno-deprecated-declarations)
 
-## visualisation
-find_package(OpenGL REQUIRED)
-find_package(GLUT REQUIRED)
-include_directories(${OPENGL_INCLUDE_DIRS} ${GLUT_INCLUDE_DIRS})
-
 ## Declare cpp executables
 add_executable(problemInterface src/ProblemGeneration/ProblemInterface.cpp src/ProblemGeneration/PDDLProblemGenerator.cpp
                                                                            src/ProblemGeneration/ProblemGenerator.cpp


### PR DESCRIPTION
I noticed that you have dependencies on OpenGL and GLUT which is not required to run rosplan itself.