### PR TITLE
Remove harcoded path in TFDPlannerInterface

### DIFF
--- a/rosplan_planning_system/src/PlannerInterface/TFDPlannerInterface.cpp
+++ b/rosplan_planning_system/src/PlannerInterface/TFDPlannerInterface.cpp
@@ -66,7 +66,7 @@ namespace KCL_rosplan {
         if(pit!=std::string::npos) str.replace(pit,7,problem_path);
 
         // path is based on the default installation of the Temporal Fast Downward
-        std::string updatePlan = "cp "+data_path+"../../rosplan_planning_system/common/bin/tfd-src-0.4/downward/tfdplan.1"+" "+data_path+"plan.pddl";
+        std::string updatePlan = "cp "+data_path+"tfdplan.1"+" "+data_path+"plan.pddl";
 
 
         // call the planer


### PR DESCRIPTION
This change is needed due to the removal of rosplan_demos and a workaround that the original author had set in the file.