### PR TITLE
Increased Simple Dispatcher Action Feedback Subscriber Message Buffer Size

### DIFF
--- a/rosplan_planning_system/src/PlanDispatch/SimplePlanDispatcher.cpp
+++ b/rosplan_planning_system/src/PlanDispatch/SimplePlanDispatcher.cpp
@@ -187,7 +187,7 @@ namespace KCL_rosplan {
 
 		std::string feedbackTopic = "action_feedback";
 		nh.getParam("action_feedback_topic", feedbackTopic);
-		ros::Subscriber feedback_sub = nh.subscribe(feedbackTopic, 1, &KCL_rosplan::SimplePlanDispatcher::feedbackCallback, &spd);
+		ros::Subscriber feedback_sub = nh.subscribe(feedbackTopic, 1000, &KCL_rosplan::SimplePlanDispatcher::feedbackCallback, &spd);
 
 		ROS_INFO("KCL: (%s) Ready to receive", ros::this_node::getName().c_str());
 		ros::spin();


### PR DESCRIPTION
For our application, we have been using the Simple Dispatcher.We at times dispatch and complete actions very rapidly. There have been instances where the Simple Dispatcher will drop important messages ('action achieved') because its subscription buffer size for feedback/status is only 1. This can cause our system to abruptly stop dispatching new commands because it is not informed that it has successfully completed the prior action. Increasing the buffer size of the action feedback status from to 1 to 1000 has solved our issue.