### PR TITLE
Fix FFPlannerInterface to use it with ffha planner

### DIFF
--- a/rosplan_planning_system/include/rosplan_planning_system/PlannerInterface/FFPlannerInterface.h
+++ b/rosplan_planning_system/include/rosplan_planning_system/PlannerInterface/FFPlannerInterface.h
@@ -18,6 +18,8 @@ namespace KCL_rosplan {
 	{
 	private:
 
+		bool use_ffha;
+
 		/* runs external commands */
 		std::string runCommand(std::string cmd);
 

--- a/rosplan_planning_system/launch/includes/planner_interface.launch
+++ b/rosplan_planning_system/launch/includes/planner_interface.launch
@@ -6,9 +6,9 @@
 	<arg name="use_problem_topic"    default="true" />
 	<arg name="problem_topic"        default="/rosplan_problem_interface/problem_instance" />
 	<arg name="planner_topic"        default="planner_output" />
-	<arg name="domain_path"          default="$(find rosplan_demos)/common/domain_turtlebot_demo.pddl" />
-	<arg name="problem_path"         default="$(find rosplan_demos)/common/problem.pddl" />
-	<arg name="data_path"            default="$(find rosplan_demos)/common/" />
+	<arg name="domain_path"          default="$(find rosplan_planning_system)/test/pddl/turtlebot/domain.pddl" />
+	<arg name="problem_path"         default="$(find rosplan_planning_system)/test/pddl/turtlebot/problem.pddl" />
+	<arg name="data_path"            default="$(find rosplan_planning_system)/test/pddl/turtlebot/" />
 	<arg name="planner_command"      default="timeout 10 $(find rosplan_planning_system)/common/bin/popf DOMAIN PROBLEM" />
 	<arg name="planner_interface"    default="popf_planner_interface" />
 	<arg name="use_ffha"		 default="false" />

--- a/rosplan_planning_system/launch/includes/planner_interface.launch
+++ b/rosplan_planning_system/launch/includes/planner_interface.launch
@@ -6,12 +6,12 @@
 	<arg name="use_problem_topic"    default="true" />
 	<arg name="problem_topic"        default="/rosplan_problem_interface/problem_instance" />
 	<arg name="planner_topic"        default="planner_output" />
-	<arg name="domain_path"          default="$(find rosplan_planning_system)/test/pddl/turtlebot/domain.pddl" />
-	<arg name="problem_path"         default="$(find rosplan_planning_system)/test/pddl/turtlebot/problem.pddl" />
-	<arg name="data_path"            default="$(find rosplan_planning_system)/test/pddl/turtlebot/" />
+	<arg name="domain_path"          default="$(find rosplan_demos)/common/domain_turtlebot_demo.pddl" />
+	<arg name="problem_path"         default="$(find rosplan_demos)/common/problem.pddl" />
+	<arg name="data_path"            default="$(find rosplan_demos)/common/" />
 	<arg name="planner_command"      default="timeout 10 $(find rosplan_planning_system)/common/bin/popf DOMAIN PROBLEM" />
 	<arg name="planner_interface"    default="popf_planner_interface" />
-
+	<arg name="use_ffha"		 default="false" />
 	<!-- planner interface -->
 	<node name="$(arg node_name)" pkg="rosplan_planning_system" type="$(arg planner_interface)" respawn="false" output="screen">
 
@@ -29,6 +29,10 @@
 
 		<!-- to run the planner -->
 		<param name="planner_command" value="$(arg planner_command)" />
+
+		<!-- ff/ffha planner-specific param -->
+		<param name="use_ffha" value="$(arg use_ffha)" />
+		
 	</node>
 
 </launch>

--- a/rosplan_planning_system/src/PlannerInterface/FFPlannerInterface.cpp
+++ b/rosplan_planning_system/src/PlannerInterface/FFPlannerInterface.cpp
@@ -89,7 +89,6 @@ namespace KCL_rosplan {
 			std::getline(planfile, line); //go to first action line
 			// First iteration line will be like   0: got_place C1
 			while (line.find("cost of plan") == line.npos and line.find("time spend") == line.npos and line.size() > 0) {
-				ROS_INFO(line.c_str());
 				std::stringstream ss(line); // To trim whitespaces
 				std::string aux;
 				// Read the action number X:

--- a/rosplan_planning_system/src/PlannerInterface/FFPlannerInterface.cpp
+++ b/rosplan_planning_system/src/PlannerInterface/FFPlannerInterface.cpp
@@ -20,7 +20,7 @@ namespace KCL_rosplan {
 		// start planning action server
 		plan_server->start();
 	}
-	
+
 	FFPlannerInterface::~FFPlannerInterface()
 	{
 		delete plan_server;
@@ -79,36 +79,27 @@ namespace KCL_rosplan {
 		bool solved = false;
 		while (not solved and std::getline(planfile, line)) {
 			// skip lines until there is a plan
-			if (line.compare("ff: found legal plan as follows") == 0) {
+			if (line.find("ff: found legal plan") != line.npos) {
 				solved = true;
 			}
 		}
 
 		// Parse the solved plan
 		if (solved) {
-			// actions look like this:
-			// step    0: got_place C1
-			//         1: find_object V1 C1
-			// plan cost: XX
-			while (std::getline(planfile, line)) { // Move to the beginning of the plan
-				if (line.substr(0, 4) == "step") {
-					line = line.substr(4); // Remove the step
-					break;
-				}
-			}
-
+			std::getline(planfile, line); //go to first action line
 			// First iteration line will be like   0: got_place C1
-			while (line.find("plan cost") == line.npos and line.find("time spend") == line.npos and line.size() > 0) {
+			while (line.find("cost of plan") == line.npos and line.find("time spend") == line.npos and line.size() > 0) {
+				ROS_INFO(line.c_str());
 				std::stringstream ss(line); // To trim whitespaces
 				std::string aux;
 				// Read the action number X:
 				ss >> aux;
-				planner_output += aux + " ("; // Add parenthesis before the action
+				planner_output += aux + " "; // Add parenthesis before the action
 				while (ss >> aux) { // Read the rest
 					planner_output += aux;
 					if (ss.good()) planner_output += " "; // Add a whitespace unless we have processed all the line
 				}
-				planner_output += ")  [0.001]\n"; // Close parenthesis and add duration
+				planner_output += "  [0.001]\n"; // Close parenthesis and add duration
 				std::getline(planfile, line);
 			}
 			// Convert to lowercase as FF prints all the actions and parameters in uppercase

--- a/rosplan_planning_system/src/PlannerInterface/FFPlannerInterface.cpp
+++ b/rosplan_planning_system/src/PlannerInterface/FFPlannerInterface.cpp
@@ -17,6 +17,8 @@ namespace KCL_rosplan {
 		node_handle->getParam("planner_topic", plannerTopic);
 		plan_publisher = node_handle->advertise<std_msgs::String>(plannerTopic, 1, true);
 
+		node_handle->param<bool>("use_ffha", this->use_ffha, false);
+
 		// start planning action server
 		plan_server->start();
 	}
@@ -86,19 +88,36 @@ namespace KCL_rosplan {
 
 		// Parse the solved plan
 		if (solved) {
-			std::getline(planfile, line); //go to first action line
+			if (this->use_ffha)
+			{
+				std::getline(planfile, line); //go to first action line
+			} else {
+			// actions look like this:
+			// step    0: got_place C1
+			//         1: find_object V1 C1
+			// plan cost: XX
+				while (std::getline(planfile, line)) { // Move to the beginning of the plan
+					if (line.substr(0, 4) == "step") {
+						line = line.substr(4); // Remove the step
+						break;
+					}
+				}
+			}
+
 			// First iteration line will be like   0: got_place C1
-			while (line.find("cost of plan") == line.npos and line.find("time spend") == line.npos and line.size() > 0) {
+			while (line.find("Total cost") == line.npos and line.find("time spend") == line.npos and line.size() > 0) {
 				std::stringstream ss(line); // To trim whitespaces
 				std::string aux;
 				// Read the action number X:
 				ss >> aux;
-				planner_output += aux + " "; // Add parenthesis before the action
+				std::string add = (use_ffha) ? " " : " (";
+				planner_output += aux + add; // Add parenthesis before the action
 				while (ss >> aux) { // Read the rest
 					planner_output += aux;
 					if (ss.good()) planner_output += " "; // Add a whitespace unless we have processed all the line
 				}
-				planner_output += "  [0.001]\n"; // Close parenthesis and add duration
+				add = (use_ffha) ? "  [0.001]\n" : ")  [0.001]\n";
+				planner_output += add; // Close parenthesis and add duration
 				std::getline(planfile, line);
 			}
 			// Convert to lowercase as FF prints all the actions and parameters in uppercase


### PR DESCRIPTION
Modified/fixed the FFPlannerInterface to be used with ffha planner (`sudo apt install ros-melodic-ffha`).
Also to use the ffha planner, start the planner interface node/launch file with following parameters

~~~ text
<include file="$(find rosplan_planning_system)/launch/includes/planner_interface.launch">
	<arg name="use_problem_topic"    value="true" />
	<arg name="problem_topic"        value="/rosplan_problem_interface/problem_instance" />
	<arg name="planner_topic"        value="planner_output" />
	<arg name="domain_path"          value="$(arg domain_path)" />
	<arg name="problem_path"         value="$(arg problem_path)" />
	<arg name="data_path"            value="$(arg data_path)" />
	<arg name="planner_command"      value="timeout 10 rosrun ffha ffha -o DOMAIN -f PROBLEM" />
	<arg name="planner_interface" 	 value="ff_planner_interface"/>
</include>
~~~

Still I'm not sure if the FFPlannerInterface is used for other FF planners aswell and if this change breaks the usage of those. 