### PR TITLE
Fix correct response in KB::updateKnowledgeArray

### DIFF
--- a/rosplan_knowledge_base/src/KnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/KnowledgeBase.cpp
@@ -185,7 +185,7 @@ namespace KCL_rosplan {
     bool KnowledgeBase::updateKnowledgeArray(ros::ServiceEvent<rosplan_knowledge_msgs::KnowledgeUpdateServiceArray::Request, rosplan_knowledge_msgs::KnowledgeUpdateServiceArray::Response> &event) {
 
         rosplan_knowledge_msgs::KnowledgeUpdateServiceArray::Request req = event.getRequest();
-        rosplan_knowledge_msgs::KnowledgeUpdateServiceArray::Response res = event.getResponse();
+        rosplan_knowledge_msgs::KnowledgeUpdateServiceArray::Response& res = event.getResponse(); // Note this is a reference! It acts as in a normal service method, where the response is passed as a reference
 
 		res.success = true;
 


### PR DESCRIPTION
After December change in the signature of the service method  (16595bb38fd920ffdd601c72937bb7ce262c7c3a), the response was not correctly being set and returned. This was causing the tests to fail