### PR TITLE
Update xdot_widget on plan execution update callback, so changes get immediately reflected on RQT

### DIFF
--- a/rosplan_rqt/src/rosplan_rqt/ROSPlanEsterelPlanViewer.py
+++ b/rosplan_rqt/src/rosplan_rqt/ROSPlanEsterelPlanViewer.py
@@ -72,6 +72,7 @@ class EsterelPlanViewerWidget(QWidget):
             self.xdot_widget.zoom_to_fit()
             # only zoom to fit for the first graph
             self.first_time_graph_received = False
+        self.xdot_widget.update()
         rospy.loginfo('Rendering graph ended !')
 
     def _handle_refresh_clicked(self, checked):


### PR DESCRIPTION
Otherwise they get reflected only when the window is redrawn for any reason

**BONUS:** [tutorial 5](https://kcl-planning.github.io/ROSPlan//tutorials/tutorial_05) doesn't mention the RQT plugin, what its much better than saving the .dot file and loading with dot.