### PR TITLE
Additional arguments for interfaced_planning_system.launch to change the planner interface

### DIFF
--- a/rosplan_planning_system/launch/interfaced_planning_system.launch
+++ b/rosplan_planning_system/launch/interfaced_planning_system.launch
@@ -18,6 +18,12 @@
   <!-- use problem.pddl or receive problem from topic -->
   <arg name="use_problem_topic" default="true" />
 
+  <!-- command to run the planner -->
+  <arg name="planner_command" default="timeout 10 $(find rosplan_planning_system)/common/bin/popf DOMAIN PROBLEM" />
+
+  <!-- interface to the planning system -->
+  <arg name="planner_interface" default="popf_planner_interface" />
+
   <!-- :::end of arguments::: -->
 
   <!-- knowledge base -->
@@ -45,7 +51,8 @@
     <arg name="domain_path"          value="$(arg domain_path)" />
     <arg name="problem_path"         value="$(arg autom_gen_problem_path)" />
     <arg name="data_path"            value="$(arg data_path)" />
-    <arg name="planner_command"      value="timeout 10 $(find rosplan_planning_system)/common/bin/popf DOMAIN PROBLEM" />
+    <arg name="planner_command"      value="$(arg planner_command)" />
+    <arg name="planner_interface"    value="$(arg planner_interface)" />
   </include>
 
   <!-- plan parsing -->


### PR DESCRIPTION
In order to easily use other planners with the launch file for 
the interfaced planning system I added two parameters
to interfaced_planning_system.launch:
* `planner_command` for running the planner
* `planner_interface` for choosing the planner interface.

They are used in the same way as in the included launch file for the
planner interface and the default values are set to match the original behaviour.
