### PR TITLE
Added script to display Esterel plans

### DIFF
--- a/rosplan_planning_system/src/show_esterel_plan.sh
+++ b/rosplan_planning_system/src/show_esterel_plan.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Usage: ./show_plan.sh <path_to_plan>.pdf
+# i.e. ./show_plan.sh /tmp/my_plan.pdf
+
+OUTPUT="/tmp/plan.pdf"
+if [ ! -z "$1" ]; then
+    OUTPUT=$1
+fi
+rostopic echo /rosplan_plan_dispatcher/plan_graph -n 1 -p | sed "N;s/.*digraph/digraph/g" | dot -Tpdf > $OUTPUT
+xdg-open $OUTPUT &
+echo "Esterel plan has been printed in $OUTPUT"


### PR DESCRIPTION
The script should simplify the viewing of esterl plans. It subscribes to the topic, processes the output and opens the PDF viewer with the plan.

Usage: `rosrun rosplan_planning_system show_esterel_plan.sh <path_to_pdf> `