### PR TITLE
Added duration parsing to operator details in knowledge base

### DIFF
--- a/rosplan_knowledge_base/include/rosplan_knowledge_base/VALVisitorOperator.h
+++ b/rosplan_knowledge_base/include/rosplan_knowledge_base/VALVisitorOperator.h
@@ -36,6 +36,8 @@ namespace KCL_rosplan {
 		/* visitor methods */
 		virtual void visit_proposition(VAL1_2::proposition *);
 		virtual void visit_operator_(VAL1_2::operator_ *);
+    	virtual void visit_action(VAL1_2::action * s);
+    	virtual void visit_durative_action(VAL1_2::durative_action * s);
 
 		virtual void visit_simple_goal(VAL1_2::simple_goal *);
 		virtual void visit_qfied_goal(VAL1_2::qfied_goal *);

--- a/rosplan_knowledge_base/src/PDDLKnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/PDDLKnowledgeBase.cpp
@@ -118,7 +118,7 @@ namespace KCL_rosplan {
         VAL1_2::operator_list* operators = domain_parser.domain->ops;
         for (VAL1_2::operator_list::const_iterator ci = operators->begin(); ci != operators->end(); ci++) {
             if((*ci)->name->symbol::getName() == req.name) {
-                op_visitor.visit_operator_(*ci);
+                (*ci)->visit(&op_visitor);
                 res.op = op_visitor.msg;
                 return true;
             }

--- a/rosplan_knowledge_msgs/msg/DomainOperator.msg
+++ b/rosplan_knowledge_msgs/msg/DomainOperator.msg
@@ -4,7 +4,8 @@
 rosplan_knowledge_msgs/DomainFormula formula
 
 # (2) duration constraint
-
+bool instant_action
+rosplan_knowledge_msgs/DomainInequality duration
 
 # (3) effect lists
 rosplan_knowledge_msgs/DomainFormula[] at_start_add_effects


### PR DESCRIPTION
This PR includes an update to the KB to store and provide durative action duration inequalities, as well as a flag to note whether an action is an instant action. The PR will also include updates to the esterel plan parser to check this flag and not include vestigial action end nodes for instant actions.