### PR TITLE
check action_completed condition for the failed state

### DIFF
--- a/rosplan_planning_system/src/PlanDispatch/EsterelPlanDispatcher.cpp
+++ b/rosplan_planning_system/src/PlanDispatch/EsterelPlanDispatcher.cpp
@@ -355,7 +355,7 @@ namespace KCL_rosplan {
         }
 
         // action completed (failed)
-        if(!action_completed[msg->action_id] && 0 == msg->status == rosplan_dispatch_msgs::ActionFeedback::ACTION_FAILED) {
+        if(!action_completed[msg->action_id] && msg->status == rosplan_dispatch_msgs::ActionFeedback::ACTION_FAILED) {
 
             // check action is part of current plan
             if(!action_received[msg->action_id]) {


### PR DESCRIPTION
One error exists when checking the action_completed using the action feedback status.
In the case of the current version, esterel_plan_dispatcher can not realize the ACTION_FAILED.